### PR TITLE
add create_resources and rename environment parameter

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -72,7 +72,7 @@ define letsencrypt::certonly (
     path        => $::path,
     environment => concat([ $venv_path_var ], $venv_vars),
     creates     => $live_path,
-    require     => Class['letsencrypt'],
+    require     => Exec['initialize letsencrypt'],
   }
 
   if $manage_cron {

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -19,7 +19,7 @@
 # [*additional_args*]
 #   An array of additional command line arguments to pass to the
 #   `letsencrypt-auto` command.
-# [*environment*]
+# [*venv_vars*]
 #   An optional array of environment variables (in addition to VENV_PATH).
 # [*manage_cron*]
 #   Boolean indicating whether or not to schedule cron job for renewal.
@@ -36,7 +36,7 @@ define letsencrypt::certonly (
   $webroot_paths        = undef,
   $letsencrypt_command  = $letsencrypt::command,
   $additional_args      = undef,
-  $environment          = [],
+  $venv_vars            = [],
   $manage_cron          = false,
   $cron_before_command  = undef,
   $cron_success_command = undef,
@@ -52,7 +52,7 @@ define letsencrypt::certonly (
   if $additional_args {
     validate_array($additional_args)
   }
-  validate_array($environment)
+  validate_array($venv_vars)
   validate_bool($manage_cron)
 
   $command_start = "${letsencrypt_command} --agree-tos certonly -a ${plugin} "
@@ -68,7 +68,7 @@ define letsencrypt::certonly (
   exec { "letsencrypt certonly ${title}":
     command     => $command,
     path        => $::path,
-    environment => concat([ $venv_path_var ], $environment),
+    environment => concat([ $venv_path_var ], $venv_vars),
     creates     => $live_path,
     require     => Class['letsencrypt'],
   }
@@ -89,7 +89,7 @@ define letsencrypt::certonly (
     $cron_minute = fqdn_rand(60, $title ) # 0 - 59, seed is title plus fqdn
     cron { "letsencrypt renew cron ${title}":
       command     => $cron_cmd,
-      environment => concat([ $venv_path_var ], $environment),
+      environment => concat([ $venv_path_var ], $venv_vars),
       user        => root,
       hour        => $cron_hour,
       minute      => $cron_minute,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,8 +48,8 @@
 #   A flag to allow using the 'register-unsafely-without-email' flag.
 # [*cron_scripts_path*]
 #   The path to put the script we'll call with cron. Defaults to $puppet_vardir/letsencrypt.
-# [*certonly*]
-#   A hash containing all the configuration for creating a certonly
+# [*certs*]
+#   A hash of letsencrypt::certonly certs to be created via create_resources
 #
 class letsencrypt (
   $email               = undef,
@@ -71,7 +71,7 @@ class letsencrypt (
   $install_method      = $letsencrypt::params::install_method,
   $agree_tos           = $letsencrypt::params::agree_tos,
   $unsafe_registration = $letsencrypt::params::unsafe_registration,
-  $certonly            = {},
+  $certs               = {},
 ) inherits letsencrypt::params {
   validate_string($path, $repo, $version, $config_file, $package_name, $package_command, $cron_scripts_path)
   if $email {
@@ -110,7 +110,6 @@ class letsencrypt (
     refreshonly => true,
   }
 
-  $real_certonly = hiera_hash('letsencrypt::certonly', $certonly)
-  create_resources(::letsencrypt::certonly, $real_certonly)
+  create_resources(::letsencrypt::certonly, $certs)
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@
 #   precedence over an 'email' setting defined in $config.
 # [*path*]
 #   The path to the letsencrypt installation.
-# [*environment*]
+# [*venv_vars*]
 #   An optional array of environment variables (in addition to VENV_PATH)
 # [*repo*]
 #   A Git URL to install the Let's encrypt client from.
@@ -51,7 +51,7 @@ class letsencrypt (
   $email               = undef,
   $path                = $letsencrypt::params::path,
   $venv_path           = $letsencrypt::params::venv_path,
-  $environment         = [],
+  $venv_vars           = [],
   $repo                = $letsencrypt::params::repo,
   $version             = $letsencrypt::params::version,
   $package_name        = $letsencrypt::params::package_name,
@@ -71,7 +71,7 @@ class letsencrypt (
   if $email {
     validate_string($email)
   }
-  validate_array($environment)
+  validate_array($venv_vars)
   validate_bool($manage_config, $manage_install, $manage_dependencies, $configure_epel, $agree_tos, $unsafe_registration)
   validate_hash($config)
   validate_re($install_method, ['^package$', '^vcs$'])
@@ -100,7 +100,7 @@ class letsencrypt (
   exec { 'initialize letsencrypt':
     command     => "${command_init} -h",
     path        => $::path,
-    environment => concat([ "VENV_PATH=${venv_path}" ], $environment),
+    environment => concat([ "VENV_PATH=${venv_path}" ], $venv_vars),
     refreshonly => true,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,8 @@
 #   A flag to agree to the Let's Encrypt Terms of Service.
 # [*unsafe_registration*]
 #   A flag to allow using the 'register-unsafely-without-email' flag.
+# [*certonly*]
+#   A hash containing all the configuration for creating a certonly
 #
 class letsencrypt (
   $email               = undef,
@@ -66,6 +68,7 @@ class letsencrypt (
   $install_method      = $letsencrypt::params::install_method,
   $agree_tos           = $letsencrypt::params::agree_tos,
   $unsafe_registration = $letsencrypt::params::unsafe_registration,
+  $certonly            = {},
 ) inherits letsencrypt::params {
   validate_string($path, $repo, $version, $config_file, $package_name, $package_command)
   if $email {
@@ -103,4 +106,8 @@ class letsencrypt (
     environment => concat([ "VENV_PATH=${venv_path}" ], $environment),
     refreshonly => true,
   }
+
+  $real_certonly = hiera_hash('letsencrypt::certonly', $certonly)
+  create_resources(::letsencrypt::certonly, $real_certonly)
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,7 +26,7 @@
 #   method.
 # [*package_name*]
 #   Name of package to use when installing the client with the `package`
-#   method. 
+#   method.
 #
 class letsencrypt::install (
   $manage_install      = $letsencrypt::manage_install,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,10 +14,10 @@ class letsencrypt::params {
     'server' => 'https://acme-v01.api.letsencrypt.org/directory',
   }
 
-  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') >= 0 {
+  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') >= 0 {
     $install_method = 'package'
-    $package_name = 'letsencrypt'
-    $package_command = 'letsencrypt'
+    $package_name = 'certbot'
+    $package_command = 'certbot'
   } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
     $install_method = 'package'
     $package_name = 'letsencrypt'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,10 +14,10 @@ class letsencrypt::params {
     'server' => 'https://acme-v01.api.letsencrypt.org/directory',
   }
 
-  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') >= 0 {
+  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') >= 0 {
     $install_method = 'package'
-    $package_name = 'certbot'
-    $package_command = 'certbot'
+    $package_name = 'letsencrypt'
+    $package_command = 'letsencrypt'
   } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
     $install_method = 'package'
     $package_name = 'letsencrypt'

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -40,7 +40,7 @@ describe 'letsencrypt' do
         end
 
         describe 'with custom environment variables' do
-          let(:additional_params) { { environment: ['FOO=bar', 'FIZZ=buzz'] } }
+          let(:additional_params) { { venv_vars: ['FOO=bar', 'FIZZ=buzz'] } }
           it { is_expected.to contain_exec('initialize letsencrypt').with_environment(['VENV_PATH=/opt/letsencrypt/.venv', 'FOO=bar', 'FIZZ=buzz']) }
         end
 

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -98,13 +98,13 @@ describe 'letsencrypt::certonly' do
 
       describe 'when specifying custom environment variables' do
         let(:title) { 'foo.example.com' }
-        let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'] } }
+        let(:params) { { venv_vars: ['FOO=bar', 'FIZZ=buzz'] } }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_environment(['VENV_PATH=/opt/letsencrypt/.venv', 'FOO=bar', 'FIZZ=buzz']) }
       end
 
       context 'with custom environment variables and manage cron' do
         let(:title) { 'foo.example.com' }
-        let(:params) { { environment: ['FOO=bar', 'FIZZ=buzz'], manage_cron: true } }
+        let(:params) { { venv_vars: ['FOO=bar', 'FIZZ=buzz'], manage_cron: true } }
 
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_environment(['VENV_PATH=/opt/letsencrypt/.venv', 'FOO=bar', 'FIZZ=buzz']) }
       end


### PR DESCRIPTION
This pulls in upstream PR #64 and #77 (with minor modifications after pulling in #77)

- renames the environment class parameter to avoid conflict with heira (upstream issue #63, PR #64)
- adds support for creating a hash of letsencrypt::certonly certs via create_resources (upstream PR #77)
- changes the parameter name and fixes a dependency chain issue with that create_resources

